### PR TITLE
Add Woodbury method for online linear regression

### DIFF
--- a/tests/testthat/test-machine_learning.R
+++ b/tests/testthat/test-machine_learning.R
@@ -1,18 +1,25 @@
 test_that("LinearRegression provides correct results", {
-    X <- matrix(c(3, 1, 4, 1, 5, 9, 2, 6), ncol = 2)
-    y <- c(2, 7, 1, 8)
-    # Initialisation
-    reg <- LinearRegression$new(X, y)
-    expect_equal(reg$value(), unname(coef(lm(y ~ X))))
-    # Updating
-    X_new <- matrix(c(5, 3, 5, 8), ncol = 2)
-    y_new <- c(2, 8)
-    reg$update(X_new, y_new)
-    expect_equal(
-        reg$value(),
-        unname(coef(lm(c(y, y_new) ~ rbind(X, X_new))))
+    methods <- c(
+        "sherman-morrison",
+        "woodbury"
     )
-    # No intercept
-    reg <- LinearRegression$new(X, y, fit_intercept = FALSE)
-    expect_equal(reg$value(), unname(coef(lm(y ~ X + 0))))
+    for (method in methods) {
+        X <- matrix(c(3, 1, 4, 1, 5, 9, 2, 6), ncol = 2)
+        y <- c(2, 7, 1, 8)
+        # Initialisation
+        reg <- LinearRegression$new(X, y, method = method)
+        expect_equal(reg$value(), unname(coef(lm(y ~ X))))
+        # Updating
+        X_new <- matrix(c(5, 3, 5, 8), ncol = 2)
+        y_new <- c(2, 8)
+        reg$update(X_new, y_new)
+        expect_equal(
+            reg$value(),
+            unname(coef(lm(c(y, y_new) ~ rbind(X, X_new))))
+        )
+        # No intercept
+        reg <- LinearRegression$new(X, y, fit_intercept = FALSE,
+                                    method = method)
+        expect_equal(reg$value(), unname(coef(lm(y ~ X + 0))))
+    }
 })


### PR DESCRIPTION
The existing online regression is based on the Sherman-Morrison identity, which only allows a rank one update (it updates the regression one row at a time – very inefficient).

This method uses a more general form of the identity by Woodbury to perform the update in one go.